### PR TITLE
Migration helpers

### DIFF
--- a/include/naoqi_driver/helpers.hpp
+++ b/include/naoqi_driver/helpers.hpp
@@ -26,21 +26,33 @@ namespace naoqi {
 namespace helpers {
 
 /**
- * @brief Time helper class, used to retrieve the time from the Driver node
- * throughout the project
+ * @brief Node helper class, holds a pointer towards the driver rclcpp::Node 
  * 
  */
-class Time {
+class Node {
 public:
   /**
    * @brief Set the Node object
    * 
-   * @param node_ptr 
+   * @param node_ptr_ 
    */
   static void setNode(const boost::shared_ptr<rclcpp::Node>& node_ptr) {
-    Time::node_ptr_ = node_ptr;
+    Node::node_ptr_ = node_ptr;
   }
 
+protected:
+  static boost::shared_ptr<rclcpp::Node> node_ptr_;
+};
+
+boost::shared_ptr<rclcpp::Node> Node::node_ptr_;
+
+/**
+ * @brief Time helper class, used to access to time related functionalities 
+ * throughout the project
+ * 
+ */
+class Time : public Node {
+public:
   /**
    * @brief Calls the method now of the node instance
    * 
@@ -49,9 +61,6 @@ public:
   static rclcpp::Time now() {
     return Time::node_ptr_->now();
   }
-
-private:
-  static boost::shared_ptr<rclcpp::Node> node_ptr_;
 };
 
 } // naoqi

--- a/include/naoqi_driver/helpers.hpp
+++ b/include/naoqi_driver/helpers.hpp
@@ -84,6 +84,19 @@ public:
 };
 
 
+class Logger : public Node {
+public:
+  /**
+   * @brief Get the logger object for the driver node
+   * 
+   * @return rclcpp::Logger 
+   */
+  static rclcpp::Logger get_logger() {
+    return Logger::node_ptr_->get_logger();
+  }
+};
+
+
 } // naoqi
 } // helpers
 

--- a/include/naoqi_driver/helpers.hpp
+++ b/include/naoqi_driver/helpers.hpp
@@ -25,6 +25,7 @@
 namespace naoqi {
 namespace helpers {
 
+
 /**
  * @brief Node helper class, holds a pointer towards the driver rclcpp::Node 
  * 
@@ -46,6 +47,7 @@ protected:
 
 boost::shared_ptr<rclcpp::Node> Node::node_ptr_;
 
+
 /**
  * @brief Time helper class, used to access to time related functionalities 
  * throughout the project
@@ -62,6 +64,25 @@ public:
     return Time::node_ptr_->now();
   }
 };
+
+
+/**
+ * @brief Publisher helper class, used to access to publisher related
+ * functionalities throughout the project
+ * 
+ */
+class Publisher : public Node {
+public:
+  /**
+   * @brief Get the number of subscribers for a publisher on a specific topic
+   * 
+   * @return int 
+   */
+  static size_t getNumSubscribers(const std::string& topic_name) {
+    return Publisher::node_ptr_->count_subscribers(topic_name);
+  }
+};
+
 
 } // naoqi
 } // helpers

--- a/include/naoqi_driver/helpers.hpp
+++ b/include/naoqi_driver/helpers.hpp
@@ -41,6 +41,24 @@ public:
     Node::node_ptr_ = node_ptr;
   }
 
+  /**
+   * @brief Get the logger object for the driver node
+   * 
+   * @return rclcpp::Logger 
+   */
+  static rclcpp::Logger get_logger() {
+    return Node::node_ptr_->get_logger();
+  }
+
+  /**
+   * @brief Get the number of subscribers for a publisher on a specific topic
+   * 
+   * @return int 
+   */
+  static size_t count_subscribers(const std::string& topic_name) {
+    return Node::node_ptr_->count_subscribers(topic_name);
+  }
+
 protected:
   static boost::shared_ptr<rclcpp::Node> node_ptr_;
 };
@@ -64,38 +82,6 @@ public:
     return Time::node_ptr_->now();
   }
 };
-
-
-/**
- * @brief Publisher helper class, used to access to publisher related
- * functionalities throughout the project
- * 
- */
-class Publisher : public Node {
-public:
-  /**
-   * @brief Get the number of subscribers for a publisher on a specific topic
-   * 
-   * @return int 
-   */
-  static size_t getNumSubscribers(const std::string& topic_name) {
-    return Publisher::node_ptr_->count_subscribers(topic_name);
-  }
-};
-
-
-class Logger : public Node {
-public:
-  /**
-   * @brief Get the logger object for the driver node
-   * 
-   * @return rclcpp::Logger 
-   */
-  static rclcpp::Logger get_logger() {
-    return Logger::node_ptr_->get_logger();
-  }
-};
-
 
 } // naoqi
 } // helpers

--- a/src/external_registration.cpp
+++ b/src/external_registration.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
   boost::shared_ptr<naoqi::Driver> bs = boost::make_shared<naoqi::Driver>();
 
   // Setup the time helper
-  naoqi::helpers::Time::setNode(bs);
+  naoqi::helpers::Node::setNode(bs);
   
   // Retrieve the parameters
   bs->declare_parameter<std::string>("nao_ip", "127.0.0.1");


### PR DESCRIPTION
Add a Node class to the helpers, to share rclcpp::Node features throughout the project.
* The __Node__ class can be used to access to some inherited methods of the Driver rclcpp::Node object throughout the project in a safe way, without modifying the node
* The __Time__ class can be used to access to time related functionalities, such as `helpers::Time::now()`

For now, the __Time__ class is kept, but ought to be removed in a near future.