### PR TITLE
Publishers refactoring

### DIFF
--- a/src/publishers/basic.hpp
+++ b/src/publishers/basic.hpp
@@ -23,7 +23,8 @@
 /*
 * ROS includes
 */
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
+#include <naoqi_driver/helpers.hpp>
 
 namespace naoqi
 {
@@ -54,18 +55,21 @@ public:
 
   virtual inline bool isSubscribed() const
   {
-    if (is_initialized_ == false) return false;
-      return pub_.getNumSubscribers() > 0;
+    if (is_initialized_ == false){
+      return false;
+    } else{
+      return helpers::publishers::getNumSubscribers(topic_) > 0;
+    }
   }
 
   virtual void publish( const T& msg )
   {
-    pub_.publish( msg );
+    pub_->publish( msg );
   }
 
-  virtual void reset( ros::NodeHandle& nh )
+  virtual void reset( rclcpp::Node& node )
   {
-    pub_ = nh.advertise<T>( this->topic_, 10 );
+    pub_ = node->create_publisher<T>( this->topic_, 10 );
     is_initialized_ = true;
   }
 
@@ -75,7 +79,7 @@ protected:
   bool is_initialized_;
 
   /** Publisher */
-  ros::Publisher pub_;
+  rclcpp::Publisher pub_;
 }; // class
 
 } // publisher

--- a/src/publishers/basic.hpp
+++ b/src/publishers/basic.hpp
@@ -58,7 +58,7 @@ public:
     if (is_initialized_ == false){
       return false;
     } else{
-      return helpers::Node::getNumSubscribers(topic_) > 0;
+      return helpers::Node::count_subscribers(topic_) > 0;
     }
   }
 

--- a/src/publishers/basic.hpp
+++ b/src/publishers/basic.hpp
@@ -79,7 +79,7 @@ protected:
   bool is_initialized_;
 
   /** Publisher */
-  rclcpp::Publisher pub_;
+  rclcpp::Publisher<T>::SharedPtr pub_;
 }; // class
 
 } // publisher

--- a/src/publishers/basic.hpp
+++ b/src/publishers/basic.hpp
@@ -58,7 +58,7 @@ public:
     if (is_initialized_ == false){
       return false;
     } else{
-      return helpers::publishers::getNumSubscribers(topic_) > 0;
+      return helpers::Node::getNumSubscribers(topic_) > 0;
     }
   }
 

--- a/src/publishers/camera.cpp
+++ b/src/publishers/camera.cpp
@@ -49,6 +49,9 @@ void CameraPublisher::publish( const sensor_msgs::msgs::Image::SharedPtr& img, c
 void CameraPublisher::reset( rclcpp::Node& node )
 {
   pub_ = image_transport::create_publisher(node, topic_);
+  /* TODO */
+  /* Specify the QoS or remove unwanted image_transports topics by disabling plugin
+  in the lanchfile. */
 
   // Unregister compressedDepth topics for non depth cameras
   // if (camera_source_!=AL::kDepthCamera)

--- a/src/publishers/camera.cpp
+++ b/src/publishers/camera.cpp
@@ -48,7 +48,7 @@ void CameraPublisher::publish( const sensor_msgs::msgs::Image::SharedPtr& img, c
 
 void CameraPublisher::reset( rclcpp::Node& node )
 {
-  pub_ = image_transport::create_publisher(node, topic_);
+  pub_ = image_transport::create_camera_publisher(node, topic_);
   /* TODO */
   /* Specify the QoS or remove unwanted image_transports topics by disabling plugin
   in the lanchfile. */

--- a/src/publishers/camera.cpp
+++ b/src/publishers/camera.cpp
@@ -41,41 +41,39 @@ CameraPublisher::~CameraPublisher()
 {
 }
 
-void CameraPublisher::publish( const sensor_msgs::ImagePtr& img, const sensor_msgs::CameraInfo& camera_info )
+void CameraPublisher::publish( const sensor_msgs::msgs::Image::SharedPtr& img, const sensor_msgs::msg::CameraInfo& camera_info )
 {
-  pub_.publish( *img, camera_info );
+  pub_->publish( *img, camera_info );
 }
 
-void CameraPublisher::reset( ros::NodeHandle& nh )
+void CameraPublisher::reset( rclcpp::Node& node )
 {
-
-  image_transport::ImageTransport it( nh );
-  pub_ = it.advertiseCamera( topic_, 1 );
+  pub_ = image_transport::create_publisher(node, topic_);
 
   // Unregister compressedDepth topics for non depth cameras
-  if (camera_source_!=AL::kDepthCamera)
-  {
-    // Get our URI as a caller
-    std::string node_name = ros::this_node::getName();
-    XmlRpc::XmlRpcValue args, result, payload;
-    args[0] = node_name;
-    args[1] = node_name;
-    ros::master::execute("lookupNode", args, result, payload, false);
-    args[2] = result[2];
+  // if (camera_source_!=AL::kDepthCamera)
+  // {
+  //   // Get our URI as a caller
+  //   std::string node_name = node->get_name();
+  //   XmlRpc::XmlRpcValue args, result, payload;
+  //   args[0] = node_name;
+  //   args[1] = node_name;
+  //   ros::master::execute("lookupNode", args, result, payload, false);
+  //   args[2] = result[2];
 
-    // List the topics to remove
-    std::vector<std::string> topic_list;
-    topic_list.push_back(std::string("/") + node_name + "/" + topic_ + std::string("/compressedDepth"));
-    topic_list.push_back(std::string("/") + node_name + "/" + topic_ + std::string("/compressedDepth/parameter_updates"));
-    topic_list.push_back(std::string("/") + node_name + "/" + topic_ + std::string("/compressedDepth/parameter_descriptions"));
+  //   // List the topics to remove
+  //   std::vector<std::string> topic_list;
+  //   topic_list.push_back(std::string("/") + node_name + "/" + topic_ + std::string("/compressedDepth"));
+  //   topic_list.push_back(std::string("/") + node_name + "/" + topic_ + std::string("/compressedDepth/parameter_updates"));
+  //   topic_list.push_back(std::string("/") + node_name + "/" + topic_ + std::string("/compressedDepth/parameter_descriptions"));
 
-    // Remove undesirable topics
-    for(std::vector<std::string>::const_iterator topic = topic_list.begin(); topic != topic_list.end(); ++topic)
-    {
-      args[1] = *topic;
-      ros::master::execute("unregisterPublisher", args, result, payload, false);
-    }
-  }
+  //   // Remove undesirable topics
+  //   for(std::vector<std::string>::const_iterator topic = topic_list.begin(); topic != topic_list.end(); ++topic)
+  //   {
+  //     args[1] = *topic;
+  //     ros::master::execute("unregisterPublisher", args, result, payload, false);
+  //   }
+  // }
 
   is_initialized_ = true;
 }

--- a/src/publishers/camera.hpp
+++ b/src/publishers/camera.hpp
@@ -56,7 +56,7 @@ public:
     if (is_initialized_ == false){
       return false;
     } else{
-      return helpers::Node::getNumSubscribers(topic_) > 0;
+      return helpers::Node::count_subscribers(topic_) > 0;
     }
   }
 

--- a/src/publishers/camera.hpp
+++ b/src/publishers/camera.hpp
@@ -21,8 +21,10 @@
 /*
 * ROS includes
 */
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/node_base_interface.hpp>
 #include <image_transport/image_transport.h>
+#include <naoqi_driver/helpers.hpp>
 
 namespace naoqi
 {
@@ -46,14 +48,17 @@ public:
     return is_initialized_;
   }
 
-  void publish( const sensor_msgs::ImagePtr& img, const sensor_msgs::CameraInfo& camera_info );
+  void publish( const sensor_msgs::msg::Image::SharedPtr& img, const sensor_msgs::msg::CameraInfo& camera_info );
 
-  void reset( ros::NodeHandle& nh );
+  void reset( rclcpp::Node& node );
 
   inline bool isSubscribed() const
   {
-    if (is_initialized_ == false) return false;
-    return pub_.getNumSubscribers() > 0;
+    if (is_initialized_ == false){
+      return false;
+    } else{
+      return helpers::publishers::getNumSubscribers(topic_) > 0;
+    }
   }
 
 private:

--- a/src/publishers/camera.hpp
+++ b/src/publishers/camera.hpp
@@ -22,7 +22,6 @@
 * ROS includes
 */
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp/node_base_interface.hpp>
 #include <image_transport/image_transport.h>
 #include <naoqi_driver/helpers.hpp>
 
@@ -57,7 +56,7 @@ public:
     if (is_initialized_ == false){
       return false;
     } else{
-      return helpers::publishers::getNumSubscribers(topic_) > 0;
+      return helpers::Node::getNumSubscribers(topic_) > 0;
     }
   }
 

--- a/src/publishers/info.cpp
+++ b/src/publishers/info.cpp
@@ -32,13 +32,15 @@ InfoPublisher::InfoPublisher(const std::string& topic , const robot::Robot& robo
 {
 }
 
-void InfoPublisher::reset( ros::NodeHandle& nh )
+void InfoPublisher::reset( rclcpp::Node& node)
 {
   // We latch as we only publish once
-  pub_ = nh.advertise<naoqi_bridge_msgs::StringStamped>( topic_, 1, true );
+  pub_ = node->create_publisher<naoqi_bridge_msgs::msg::StringStamped>( topic_, 1, true );
 
   std::string robot_desc = naoqi::tools::getRobotDescription(robot_);
-  nh.setParam("/robot_description", robot_desc);
+  std::string parameter_name = "/robot_description"
+  rclcpp::ParameterValue value = node->declare_parameter(parameter_name);
+  node->set_parameters({parameter_name, robot_desc});
   std::cout << "load robot description from file" << std::endl;
 
   is_initialized_ = true;

--- a/src/publishers/info.cpp
+++ b/src/publishers/info.cpp
@@ -35,7 +35,7 @@ InfoPublisher::InfoPublisher(const std::string& topic , const robot::Robot& robo
 void InfoPublisher::reset( rclcpp::Node& node)
 {
   // We latch as we only publish once
-  pub_ = node->create_publisher<naoqi_bridge_msgs::msg::StringStamped>( topic_, 1, true );
+  pub_ = node->create_publisher<naoqi_bridge_msgs::msg::StringStamped>( topic_, 1);
 
   std::string robot_desc = naoqi::tools::getRobotDescription(robot_);
   std::string parameter_name = "/robot_description"

--- a/src/publishers/info.hpp
+++ b/src/publishers/info.hpp
@@ -28,7 +28,7 @@
 * ROS includes
 */
 #include <rclcpp/rclcpp.hpp>
-#include <naoqi_bridge_msgs/msg/StringStamped.hpp>
+#include <naoqi_bridge_msgs/msg/string_stamped.hpp>
 
 namespace naoqi
 {

--- a/src/publishers/info.hpp
+++ b/src/publishers/info.hpp
@@ -27,20 +27,20 @@
 /*
 * ROS includes
 */
-#include <ros/ros.h>
-#include <naoqi_bridge_msgs/StringStamped.h>
+#include <rclcpp/rclcpp.hpp>
+#include <naoqi_bridge_msgs/msg/StringStamped.hpp>
 
 namespace naoqi
 {
 namespace publisher
 {
 
-class InfoPublisher : public BasicPublisher<naoqi_bridge_msgs::StringStamped>
+class InfoPublisher : public BasicPublisher<naoqi_bridge_msgs::msg::StringStamped>
 {
 public:
   InfoPublisher( const std::string& topic, const robot::Robot& robot_type );
 
-  void reset( ros::NodeHandle& nh );
+  void reset( rclcpp::Node& node );
 
   virtual inline bool isSubscribed() const
   {

--- a/src/publishers/joint_state.cpp
+++ b/src/publishers/joint_state.cpp
@@ -30,10 +30,10 @@ JointStatePublisher::JointStatePublisher( const std::string& topic ):
   is_initialized_( false )
 {}
 
-void JointStatePublisher::publish( const sensor_msgs::JointState& js_msg,
-                                   const std::vector<geometry_msgs::TransformStamped>& tf_transforms )
+void JointStatePublisher::publish( const sensor_msgs::msg::JointState& js_msg,
+                                   const std::vector<geometry_msgs::msg::TransformStamped>& tf_transforms )
 {
-  pub_joint_states_.publish( js_msg );
+  pub_joint_states_->publish( js_msg );
 
   /**
    * ROBOT STATE PUBLISHER
@@ -42,9 +42,9 @@ void JointStatePublisher::publish( const sensor_msgs::JointState& js_msg,
 }
 
 
-void JointStatePublisher::reset( ros::NodeHandle& nh )
+void JointStatePublisher::reset( rclcpp::Node& node )
 {
-  pub_joint_states_ = nh.advertise<sensor_msgs::JointState>( topic_, 10 );
+  pub_joint_states_ = node.create_publisher<sensor_msgs::msg::JointState>( topic_, 10 );
 
   tf_broadcasterPtr_ = boost::make_shared<tf2_ros::TransformBroadcaster>();
 

--- a/src/publishers/joint_state.cpp
+++ b/src/publishers/joint_state.cpp
@@ -44,7 +44,7 @@ void JointStatePublisher::publish( const sensor_msgs::msg::JointState& js_msg,
 
 void JointStatePublisher::reset( rclcpp::Node& node )
 {
-  pub_joint_states_ = node.create_publisher<sensor_msgs::msg::JointState>( topic_, 10 );
+  pub_joint_states_ = node->create_publisher<sensor_msgs::msg::JointState>( topic_, 10 );
 
   tf_broadcasterPtr_ = boost::make_shared<tf2_ros::TransformBroadcaster>();
 

--- a/src/publishers/joint_state.hpp
+++ b/src/publishers/joint_state.hpp
@@ -21,9 +21,9 @@
 /*
 * ROS includes
 */
-#include <ros/ros.h>
-#include <geometry_msgs/Transform.h>
-#include <sensor_msgs/JointState.h>
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/transform.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 
 namespace naoqi
@@ -47,10 +47,10 @@ public:
   return is_initialized_;
   }
 
-  virtual void publish( const sensor_msgs::JointState& js_msg,
-                        const std::vector<geometry_msgs::TransformStamped>& tf_transforms );
+  virtual void publish( const sensor_msgs::msg::JointState& js_msg,
+                        const std::vector<geometry_msgs::msg::TransformStamped>& tf_transforms );
 
-  virtual void reset( ros::NodeHandle& nh );
+  virtual void reset( rclcpp::Node& node );
 
   virtual bool isSubscribed() const;
 
@@ -58,7 +58,7 @@ private:
   boost::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcasterPtr_;
 
   /** initialize separate publishers for js and odom */
-  ros::Publisher pub_joint_states_;
+  rclcpp::Publisher pub_joint_states_;
 
   std::string topic_;
 

--- a/src/publishers/joint_state.hpp
+++ b/src/publishers/joint_state.hpp
@@ -58,7 +58,7 @@ private:
   boost::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcasterPtr_;
 
   /** initialize separate publishers for js and odom */
-  rclcpp::Publisher pub_joint_states_;
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr pub_joint_states_;
 
   std::string topic_;
 

--- a/src/publishers/log.hpp
+++ b/src/publishers/log.hpp
@@ -28,7 +28,6 @@
 */
 #include <rclcpp/rclcpp.hpp>
 #include <rcl_interfaces/msg/log.hpp>
-#include <rclcpp/serialization.h>
 #include <std_msgs/String.h>
 
 /*
@@ -65,7 +64,7 @@ public:
   }
 
 private:
-  rclcpp::Publisher pub_;
+  rclcpp::Publisher<rcl_interfaces::msg::Log>::SharedPtr pub_;
 
 };
 

--- a/src/publishers/log.hpp
+++ b/src/publishers/log.hpp
@@ -26,9 +26,9 @@
 /*
 * ROS includes
 */
-#include <ros/ros.h>
-#include <rosgraph_msgs/Log.h>
-#include <ros/serialization.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rcl_interfaces/msg/log.hpp>
+#include <rclcpp/serialization.h>
 #include <std_msgs/String.h>
 
 /*
@@ -50,7 +50,7 @@ namespace naoqi
 namespace publisher
 {
 
-class LogPublisher : public BasicPublisher<rosgraph_msgs::Log>
+class LogPublisher : public BasicPublisher<rcl_interfaces::msg::Log>
 {
 public:
   LogPublisher(const std::string& topic);
@@ -65,7 +65,7 @@ public:
   }
 
 private:
-  ros::Publisher pub_;
+  rclcpp::Publisher pub_;
 
 };
 

--- a/src/publishers/memory/bool.cpp
+++ b/src/publishers/memory/bool.cpp
@@ -29,14 +29,14 @@ MemoryBoolPublisher::MemoryBoolPublisher( const std::string& topic ):
   BasePublisher( topic )
 {}
 
-void MemoryBoolPublisher::publish(const naoqi_bridge_msgs::BoolStamped& msg )
+void MemoryBoolPublisher::publish(const naoqi_bridge_msgs::msg::BoolStamped& msg )
 {
-  pub_.publish( msg );
+  pub_->publish( msg );
 }
 
-void MemoryBoolPublisher::reset( ros::NodeHandle& nh )
+void MemoryBoolPublisher::reset( rclcpp::Node& node )
 {
-  pub_ = nh.advertise< naoqi_bridge_msgs::BoolStamped >( topic_, 10 );
+  pub_ = node->create_publisher< naoqi_bridge_msgs::msg::BoolStamped >( topic_, 10 );
   is_initialized_ = true;
 }
 

--- a/src/publishers/memory/bool.hpp
+++ b/src/publishers/memory/bool.hpp
@@ -26,7 +26,7 @@
 /*
 * ROS includes
 */
-#include <naoqi_bridge_msgs/msg/BoolStamped.hpp>
+#include <naoqi_bridge_msgs/msg/bool_stamped.hpp>
 
 namespace naoqi
 {

--- a/src/publishers/memory/bool.hpp
+++ b/src/publishers/memory/bool.hpp
@@ -26,22 +26,22 @@
 /*
 * ROS includes
 */
-#include <naoqi_bridge_msgs/BoolStamped.h>
+#include <naoqi_bridge_msgs/msg/BoolStamped.hpp>
 
 namespace naoqi
 {
 namespace publisher
 {
 
-class MemoryBoolPublisher : public BasePublisher<naoqi_bridge_msgs::BoolStamped>
+class MemoryBoolPublisher : public BasePublisher<naoqi_bridge_msgs::msg::BoolStamped>
 {
 
 public:
   MemoryBoolPublisher( const std::string& topic );
 
-  void publish( const naoqi_bridge_msgs::BoolStamped& msg );
+  void publish( const naoqi_bridge_msgs::msg::BoolStamped& msg );
 
-  void reset( ros::NodeHandle& nh );
+  void reset( rclcpp::Node& node );
 
 }; // class
 

--- a/src/publishers/memory/float.cpp
+++ b/src/publishers/memory/float.cpp
@@ -29,14 +29,14 @@ MemoryFloatPublisher::MemoryFloatPublisher( const std::string& topic ):
   BasePublisher( topic )
 {}
 
-void MemoryFloatPublisher::publish( const naoqi_bridge_msgs::FloatStamped& msg )
+void MemoryFloatPublisher::publish( const naoqi_bridge_msgs::msg::FloatStamped& msg )
 {
-  pub_.publish( msg );
+  pub_->publish( msg );
 }
 
-void MemoryFloatPublisher::reset( ros::NodeHandle& nh )
+void MemoryFloatPublisher::reset( rclcpp::Node& node )
 {
-  pub_ = nh.advertise< naoqi_bridge_msgs::FloatStamped >( topic_, 10 );
+  pub_ = node->create_publisher< naoqi_bridge_msgs::msg::FloatStamped >( topic_, 10 );
   is_initialized_ = true;
 }
 

--- a/src/publishers/memory/float.hpp
+++ b/src/publishers/memory/float.hpp
@@ -26,7 +26,7 @@
 /*
 * ROS includes
 */
-#include <naoqi_bridge_msgs/msg/FloatStamped.h>
+#include <naoqi_bridge_msgs/msg/float_stamped.hpp>
 
 namespace naoqi
 {

--- a/src/publishers/memory/float.hpp
+++ b/src/publishers/memory/float.hpp
@@ -26,22 +26,22 @@
 /*
 * ROS includes
 */
-#include <naoqi_bridge_msgs/FloatStamped.h>
+#include <naoqi_bridge_msgs/msg/FloatStamped.h>
 
 namespace naoqi
 {
 namespace publisher
 {
 
-class MemoryFloatPublisher : public BasePublisher<naoqi_bridge_msgs::FloatStamped>
+class MemoryFloatPublisher : public BasePublisher<naoqi_bridge_msgs::msg::FloatStamped>
 {
 
 public:
   MemoryFloatPublisher( const std::string& topic );
 
-  void publish( const naoqi_bridge_msgs::FloatStamped& msg );
+  void publish( const naoqi_bridge_msgs::msg::FloatStamped& msg );
 
-  void reset( ros::NodeHandle& nh );
+  void reset( rclcpp::Node& node );
 
 }; // class
 

--- a/src/publishers/memory/int.cpp
+++ b/src/publishers/memory/int.cpp
@@ -29,14 +29,14 @@ MemoryIntPublisher::MemoryIntPublisher( const std::string& topic ):
   BasePublisher( topic )
 {}
 
-void MemoryIntPublisher::publish(const naoqi_bridge_msgs::IntStamped& msg )
+void MemoryIntPublisher::publish(const naoqi_bridge_msgs::msg::IntStamped& msg )
 {
-  pub_.publish( msg );
+  pub_->publish( msg );
 }
 
-void MemoryIntPublisher::reset( ros::NodeHandle& nh )
+void MemoryIntPublisher::reset( ros::Node& node )
 {
-  pub_ = nh.advertise< naoqi_bridge_msgs::IntStamped >( topic_, 10 );
+  pub_ = node->create_publisher< naoqi_bridge_msgs::msg::IntStamped >( topic_, 10 );
   is_initialized_ = true;
 }
 

--- a/src/publishers/memory/int.hpp
+++ b/src/publishers/memory/int.hpp
@@ -26,22 +26,22 @@
 /*
 * ROS includes
 */
-#include <naoqi_bridge_msgs/IntStamped.h>
+#include <naoqi_bridge_msgs/msg/IntStamped.h>
 
 namespace naoqi
 {
 namespace publisher
 {
 
-class MemoryIntPublisher : public BasePublisher<naoqi_bridge_msgs::IntStamped>
+class MemoryIntPublisher : public BasePublisher<naoqi_bridge_msgs::msg::IntStamped>
 {
 
 public:
   MemoryIntPublisher( const std::string& topic );
 
-  void publish( const naoqi_bridge_msgs::IntStamped& msg );
+  void publish( const naoqi_bridge_msgs::msg::IntStamped& msg );
 
-  void reset( ros::NodeHandle& nh );
+  void reset( rclcpp::Node& node );
 
 }; // class
 

--- a/src/publishers/memory/int.hpp
+++ b/src/publishers/memory/int.hpp
@@ -26,7 +26,7 @@
 /*
 * ROS includes
 */
-#include <naoqi_bridge_msgs/msg/IntStamped.h>
+#include <naoqi_bridge_msgs/msg/int_stamped.hpp>
 
 namespace naoqi
 {

--- a/src/publishers/memory/string.cpp
+++ b/src/publishers/memory/string.cpp
@@ -30,14 +30,14 @@ MemoryStringPublisher::MemoryStringPublisher( const std::string& topic ):
 {
 }
 
-void MemoryStringPublisher::publish( const naoqi_bridge_msgs::StringStamped& msg )
+void MemoryStringPublisher::publish( const naoqi_bridge_msgs::msg::StringStamped& msg )
 {
-  pub_.publish( msg );
+  pub_->publish( msg );
 }
 
-void MemoryStringPublisher::reset( ros::NodeHandle& nh )
+void MemoryStringPublisher::reset( ros::Node& node )
 {
-  pub_ = nh.advertise<naoqi_bridge_msgs::StringStamped>( topic_, 10 );
+  pub_ = node->create_publisher<naoqi_bridge_msgs::msg::StringStamped>( topic_, 10 );
   is_initialized_ = true;
 }
 

--- a/src/publishers/memory/string.hpp
+++ b/src/publishers/memory/string.hpp
@@ -26,22 +26,22 @@
 /*
 * ROS includes
 */
-#include <naoqi_bridge_msgs/StringStamped.h>
+#include <naoqi_bridge_msgs/msg/StringStamped.h>
 
 namespace naoqi
 {
 namespace publisher
 {
 
-class MemoryStringPublisher : public BasePublisher<naoqi_bridge_msgs::StringStamped>
+class MemoryStringPublisher : public BasePublisher<naoqi_bridge_msgs::msg::StringStamped>
 {
 
 public:
   MemoryStringPublisher( const std::string& topic );
 
-  void publish( const naoqi_bridge_msgs::StringStamped& msg );
+  void publish( const naoqi_bridge_msgs::msg::StringStamped& msg );
 
-  void reset( ros::NodeHandle& nh );
+  void reset( rclcpp::Node& node );
 }; // class
 
 } //publisher

--- a/src/publishers/memory/string.hpp
+++ b/src/publishers/memory/string.hpp
@@ -26,7 +26,7 @@
 /*
 * ROS includes
 */
-#include <naoqi_bridge_msgs/msg/StringStamped.h>
+#include <naoqi_bridge_msgs/msg/string_stamped.hpp>
 
 namespace naoqi
 {

--- a/src/publishers/sonar.cpp
+++ b/src/publishers/sonar.cpp
@@ -31,7 +31,7 @@ SonarPublisher::SonarPublisher( const std::vector<std::string>& topics )
 {
 }
 
-void SonarPublisher::publish( const std::vector<sensor_msgs::Range>& sonar_msgs )
+void SonarPublisher::publish( const std::vector<sensor_msgs::msg::Range>& sonar_msgs )
 {
   if ( pubs_.size() != sonar_msgs.size() )
   {
@@ -41,16 +41,16 @@ void SonarPublisher::publish( const std::vector<sensor_msgs::Range>& sonar_msgs 
 
   for( size_t i=0; i<sonar_msgs.size(); ++i)
   {
-    pubs_[i].publish( sonar_msgs[i] );
+    pubs_[i]->publish( sonar_msgs[i] );
   }
 }
 
-void SonarPublisher::reset( ros::NodeHandle& nh )
+void SonarPublisher::reset( rclcpp::Node& node )
 {
-  pubs_ = std::vector<ros::Publisher>();
+  pubs_ = std::vector<rclcpp::Publisher>();
   for( size_t i=0; i<topics_.size(); ++i)
   {
-    pubs_.push_back( nh.advertise<sensor_msgs::Range>(topics_[i], 1) );
+    pubs_.push_back( node.create_publisher<sensor_msgs::msg::Range>(topics_[i], 1) );
   }
 
   is_initialized_ = true;

--- a/src/publishers/sonar.cpp
+++ b/src/publishers/sonar.cpp
@@ -47,10 +47,10 @@ void SonarPublisher::publish( const std::vector<sensor_msgs::msg::Range>& sonar_
 
 void SonarPublisher::reset( rclcpp::Node& node )
 {
-  pubs_ = std::vector<rclcpp::Publisher>();
+  pubs_.clear();
   for( size_t i=0; i<topics_.size(); ++i)
   {
-    pubs_.push_back( node.create_publisher<sensor_msgs::msg::Range>(topics_[i], 1) );
+    pubs_.push_back( node->create_publisher<sensor_msgs::msg::Range>(topics_[i], 1) );
   }
 
   is_initialized_ = true;

--- a/src/publishers/sonar.hpp
+++ b/src/publishers/sonar.hpp
@@ -53,15 +53,15 @@ public:
   inline bool isSubscribed() const
   {
     if (is_initialized_ == false) return false;
-    for(std::vector<rclcpp::Publisher>::const_iterator it = pubs_.begin(); it != pubs_.end(); ++it)
-      if (helpers::publishers::getNumSubscribers(it->get_topic_name()))
+    for(std::vector<rclcpp::Publisher<sensor_msgs::msg::Range>::SharedPtr>::const_iterator it = pubs_.begin(); it != pubs_.end(); ++it)
+      if (helpers::Node::count_subcribers(it->get_topic_name()))
         return true;
     return false;
   }
 
 private:
   std::vector<std::string> topics_;
-  std::vector<rclcpp::Publisher> pubs_;
+  std::vector<rclcpp::Publisher<sensor_msgs::msg::Range>::SharedPtr> pubs_;
   bool is_initialized_;
 
 };

--- a/src/publishers/sonar.hpp
+++ b/src/publishers/sonar.hpp
@@ -21,8 +21,10 @@
 /*
 * ROS includes
 */
-#include <ros/ros.h>
-#include <sensor_msgs/Range.h>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/range.hpp>
+#include <naoqi_driver/helpers.hpp>
+
 
 namespace naoqi
 {
@@ -44,22 +46,22 @@ public:
     return is_initialized_;
   }
 
-  void publish( const std::vector<sensor_msgs::Range>& sonar_msgs );
+  void publish( const std::vector<sensor_msgs::msg::Range>& sonar_msgs );
 
-  void reset( ros::NodeHandle& nh );
+  void reset( rclcpp::Node& node );
 
   inline bool isSubscribed() const
   {
     if (is_initialized_ == false) return false;
-    for(std::vector<ros::Publisher>::const_iterator it = pubs_.begin(); it != pubs_.end(); ++it)
-      if (it->getNumSubscribers())
+    for(std::vector<rclcpp::Publisher>::const_iterator it = pubs_.begin(); it != pubs_.end(); ++it)
+      if (helpers::publishers::getNumSubscribers(it->get_topic_name()))
         return true;
     return false;
   }
 
 private:
   std::vector<std::string> topics_;
-  std::vector<ros::Publisher> pubs_;
+  std::vector<rclcpp::Publisher> pubs_;
   bool is_initialized_;
 
 };

--- a/src/publishers/sonar.hpp
+++ b/src/publishers/sonar.hpp
@@ -54,7 +54,7 @@ public:
   {
     if (is_initialized_ == false) return false;
     for(std::vector<rclcpp::Publisher<sensor_msgs::msg::Range>::SharedPtr>::const_iterator it = pubs_.begin(); it != pubs_.end(); ++it)
-      if (helpers::Node::count_subcribers(it->get_topic_name()))
+      if (helpers::Node::count_subcribers((*it)->get_topic_name()))
         return true;
     return false;
   }


### PR DESCRIPTION
Check if the camera publisher publishes topics like /compressedDepth. The code that remove in all camera topics, except depth, is commented. Deactivate compressed_depth_image_transport plugins or remove the topics in camera.cpp can be a solution.